### PR TITLE
chore(environment): add commitizen config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,10 @@
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.4",
     "webpack-serve": "^2.0.2"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
To use commitizen:
 - npm install -g commitizen
 - npm install -g cz-conventional-changelog

then, when you want to commit something, use git cz instead of git commit

[more info](http://commitizen.github.io/cz-cli/)